### PR TITLE
Updated to React 0.13 and FontAwesome 4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Use the following webpack config (put it in `webpack.config.js`):
             loader: ExtractTextPlugin.extract('style-loader', 'css-loader')
           },
           {
-            test: /\.(otf|eot|svg|ttf|woff)$/,
+            test: /\.(otf|eot|svg|ttf|woff|woff2)$/,
             loader: 'url-loader?limit=8192'
           }
         ]

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
         loader: ExtractTextPlugin.extract('style-loader', 'css-loader')
       },
       {
-        test: /\.(otf|eot|svg|ttf|woff)$/,
+        test: /\.(otf|eot|svg|ttf|woff|woff2)$/,
         loader: 'url-loader?limit=8192'
       }
     ]

--- a/package.json
+++ b/package.json
@@ -4,17 +4,17 @@
   "description": "Font Awesome icons as React components",
   "main": "dist/index.js",
   "dependencies": {
-    "font-awesome": "^4.2.0"
+    "font-awesome": "^4.3.0"
   },
   "peerDependencies": {
-    "react": "^0.12.0"
+    "react": "^0.13.1"
   },
   "devDependencies": {
-    "react": "^0.12.0",
-    "react-tools": "^0.12.2",
+    "react": "^0.13.1",
+    "react-tools": "^0.13.1",
     "css-loader": "^0.7.1",
     "extract-text-webpack-plugin": "^0.3.1",
-    "jsx-loader": "^0.12.0",
+    "jsx-loader": "^0.12.2",
     "jsxhint": "^0.4.14",
     "style-loader": "^0.7.1",
     "url-loader": "^0.5.5",


### PR DESCRIPTION
I've updated the version of FontAwesome to have 4.3 icons and updated the peerDeeps and package.json to support React 0.13.x
