### PR TITLE
replace span with i

### DIFF
--- a/src/Icon.js
+++ b/src/Icon.js
@@ -52,7 +52,7 @@ var Icon = React.createClass({
     if (className) {
       classNames += ` ${className}`;
     }
-    return <span {...props} className={classNames} />;
+    return <i {...props} className={classNames}></i>;
   }
 });
 


### PR DESCRIPTION
Any reason for a span instead of font-awesome's idiomatic `<i>`?
