### PR TITLE
Fix mistype in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ module.exports = {
       },
       {
         test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-        loader: 'url-loader?limit=10000&minetype=application/font-woff'
+        loader: 'url-loader?limit=10000&mimetype=application/font-woff'
       },
       {
         test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,


### PR DESCRIPTION
Not a critical one, but a mistype either way.
