### PR TITLE
IconStack default size of implicit `1x`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ ReactDOM.renderComponent(
 )
 ```
 
-### Component API
+### Icon Component API
 
 **Props in `[]` are optional**
 
@@ -55,6 +55,14 @@ ReactDOM.renderComponent(
 |[stack]     |`string` |`undefined`|Stack Icons: '1x', '2x'. [More Info][]
 |[inverse]   |`boolean`|`false`|Inverse the Icon color|
 |[Component] |`string/func`|`span`|Alternate DOM element |
+
+### IconStack Component API
+
+|Prop       |Type    |Default    |Description                                 |
+|-----------|:------:|:---------:|--------------------------------------------|
+|[children] |`node`|`undefined`|Required: Child elements |
+|[size]     |`string`|`undefined`|Increase size: 'lg', '2x', '3x', '4x', '5x' |
+|[className]|`string`|`undefined`|Set a CSS class for extra styles            |
 
 ## Webpack Setup
 

--- a/src/IconStack.js
+++ b/src/IconStack.js
@@ -12,10 +12,6 @@ export default class IconStack extends React.Component {
     children: PropTypes.node.isRequired
   };
 
-  static defaultProps = {
-    size: 'lg',
-  };
-
   render() {
     let {
       className,
@@ -24,14 +20,20 @@ export default class IconStack extends React.Component {
       ...props
     } = this.props;
 
-    let classNames = `fa-stack fa-${size}`;
+    let classNames = ['fa-stack'];
 
-    if (className) {
-      classNames = `${classNames} ${className}`;
+    if (size) {
+      classNames.push(`fa-${size}`);
     }
 
+    if (className) {
+      classNames.push(className);
+    }
+
+    const iconStackClassName = classNames.join(' ');
+
     return (
-      <span {...props} className={classNames}>
+      <span {...props} className={iconStackClassName}>
         {children}
       </span>
     );

--- a/src/README.md
+++ b/src/README.md
@@ -21,7 +21,7 @@
 |Prop       |Type    |Default    |Description                                 |
 |-----------|:------:|:---------:|--------------------------------------------|
 |[children] |`node`|`undefined`|Required: Child elements |
-|[size]     |`string`|`lg`|Stack size: 'lg', '2x', '3x', '4x', '5x' |
+|[size]     |`string`|`undefined`|Increase size: 'lg', '2x', '3x', '4x', '5x' |
 |[className]|`string`|`undefined`|Set a CSS class for extra styles            |
 
 

--- a/src/__tests__/IconStack-test.js
+++ b/src/__tests__/IconStack-test.js
@@ -16,7 +16,7 @@ describe('IconStack', function() {
         <Icon name='plus' />
       </IconStack>
     )
-    assert(/<span class="fa-stack fa-lg"/.exec(markup))
+    assert(/<span class="fa-stack"/.exec(markup))
   });
 
   it('supports optional "size"', function() {
@@ -34,6 +34,6 @@ describe('IconStack', function() {
         <Icon name='plus' />
       </IconStack>
     )
-    assert(/<span class="fa-stack fa-lg x"/.exec(markup))
+    assert(/<span class="fa-stack x"/.exec(markup))
   });
 });


### PR DESCRIPTION
Corrects the default `IconStack` size to `1x` which aligns with Font Awesome default icon stack size.  The `IconStack` component currently has no way of reaching the `1x` size without supplying an unspecified `size` property and yielding a `Failed propType` assertion warning.  Additionally this also aligns the size interface of `IconStack` with that of the `Icon` component.

Updated tests and documentation to reflect change.
