### PR TITLE
Clean way to handle joining class names together

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Font Awesome icons as React components",
   "main": "lib/index.js",
   "dependencies": {
-    "font-awesome": "^4.3.0"
+    "font-awesome": "^4.3.0",
+    "joinable": "^1.3.0"
   },
   "peerDependencies": {
     "react": ">= 0.13.0 <16.0.0"
@@ -29,7 +30,7 @@
     "webpack": "^1.12.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha --compilers js:babel-core/register src/__tests__/*.js"
   },
   "repository": {
     "type": "git",

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -31,8 +31,8 @@ export default class Icon extends React.Component {
       name, size, rotate, flip, spin, fixedWidth, stack, inverse,
       pulse, className, ...props
     } = this.props;
-    
-    let classNames = joinClassNames(
+
+    const classNames = joinClassNames(
       'fa', 
       `fa-${name}`,
       [size, `fa-${size}`],

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -3,6 +3,7 @@
  */
 
 import React, {PropTypes} from 'react';
+import joinClassNames from 'joinable';
 
 export default class Icon extends React.Component {
 
@@ -30,36 +31,20 @@ export default class Icon extends React.Component {
       name, size, rotate, flip, spin, fixedWidth, stack, inverse,
       pulse, className, ...props
     } = this.props;
-    let classNames = `fa fa-${name}`;
-    if (size) {
-      classNames = `${classNames} fa-${size}`;
-    }
-    if (rotate) {
-      classNames = `${classNames} fa-rotate-${rotate}`;
-    }
-    if (flip) {
-      classNames = `${classNames} fa-flip-${flip}`;
-    }
-    if (fixedWidth) {
-      classNames = `${classNames} fa-fw`;
-    }
-    if (spin) {
-      classNames = `${classNames} fa-spin`;
-    }
-    if (pulse) {
-      classNames = `${classNames} fa-pulse`;
-    }
+    
+    let classNames = joinClassNames(
+      'fa', 
+      `fa-${name}`,
+      [size, `fa-${size}`],
+      [rotate, `fa-rotate-${rotate}`],
+      [flip, `fa-flip-${flip}`],
+      [fixedWidth, 'fa-fw'],
+      [spin, 'fa-spin'],
+      [pulse, 'fa-pulse'],
+      [stack, `fa-stack-${stack}`],
+      [inverse, 'fa-inverse'],
+      className);
 
-    if (stack) {
-      classNames = `${classNames} fa-stack-${stack}`;
-    }
-    if (inverse) {
-      classNames = `${classNames} fa-inverse`;
-    }
-
-    if (className) {
-      classNames = `${classNames} ${className}`;
-    }
     return <Component {...props} className={classNames} />;
   }
 }

--- a/src/IconStack.js
+++ b/src/IconStack.js
@@ -3,6 +3,7 @@
  */
 
 import React, {PropTypes} from 'react';
+import joinClassNames from 'joinable';
 
 export default class IconStack extends React.Component {
 
@@ -20,17 +21,7 @@ export default class IconStack extends React.Component {
       ...props
     } = this.props;
 
-    let classNames = ['fa-stack'];
-
-    if (size) {
-      classNames.push(`fa-${size}`);
-    }
-
-    if (className) {
-      classNames.push(className);
-    }
-
-    const iconStackClassName = classNames.join(' ');
+    const iconStackClassName = joinClassNames('fa-stack', [size, `fa-${size}`], className);
 
     return (
       <span {...props} className={iconStackClassName}>


### PR DESCRIPTION
I was using your library for one of my projects and had a look at your source code. I noticed the number of if statements used to handle concatenating the css classes together.

I noticed this appearing a lot in my projects and I built `joinable` to handle joining strings with conditions. I find this makes the code look cleaner, less complex and readable.

Thought I would share it to see if you would like to use it.

[Info on Joinable](https://github.com/rkotze/joinable)
