### PR TITLE
add extrastyles for rotate

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ ReactDOM.renderComponent(
 |name       |`string`|`undefined`|Required: Name of the Font Awesome Icon     |
 |[className]|`string`|`undefined`|Set a CSS class for extra styles            |
 |[size]     |`string`|`undefined`|Increase size: 'lg', '2x', '3x', '4x', '5x' |
-|[rotate]   |`string`|`undefined`|Rotate by deg: '45', '90', '135', '180', '225', '270', '315'|
+|[rotate]   |`string`|`undefined`|Rotate by deg:  '90', '180', '270'  (extra: '45', '135', '225', '315')|
 |[flip]     |`string`|`undefined`|Flips Icon: 'horizontal', 'vertical'        |
 |[fixedWidth]|`boolean`|`false`|Set Icon to a fixed width                   |
 |[spin]     |`boolean`| `false`|Rotate Icon|

--- a/src/README.md
+++ b/src/README.md
@@ -8,7 +8,7 @@
 |name       |`string`|`undefined`|Required: Name of the Font Awesome Icon     |
 |[className]|`string`|`undefined`|Set a CSS class for extra styles            |
 |[size]     |`string`|`undefined`|Increase size: 'lg', '2x', '3x', '4x', '5x' |
-|[rotate]   |`string`|`undefined`|Rotate by deg: '45', '90', '135', '180', '225', '270', '315'|
+|[rotate]   |`string`|`undefined`|Rotate by deg:  '90', '180', '270'  (extra: '45', '135', '225', '315')|
 |[flip]     |`string`|`undefined`|Flips Icon: 'horizontal', 'vertical'        |
 |[fixedWidth]|`boolean`|`false`|Set Icon to a fixed width                   |
 |[spin]     |`boolean`| `false`|Rotate Icon|

--- a/src/extrastyles.css
+++ b/src/extrastyles.css
@@ -1,0 +1,25 @@
+//intermediate angles for icon rotation
+.fa-rotate-45 {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+.fa-rotate-135 {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2)";
+  -webkit-transform: rotate(135deg);
+  -ms-transform: rotate(135deg);
+  transform: rotate(135deg);
+}
+.fa-rotate-225 {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=3)";
+  -webkit-transform: rotate(225deg);
+  -ms-transform: rotate(225deg);
+  transform: rotate(225deg);
+}
+.fa-rotate-315 {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=0)";
+  -webkit-transform: rotate(315deg);
+  -ms-transform: rotate(315deg);
+  transform: rotate(315deg);
+}


### PR DESCRIPTION
If your component support such useful modificators for rotate, must add styles, even @FortAwesome doesn't support it. By the way, this mods not working in old IEs, because they have poor transformation support
