### PR TITLE
React.PropTypes is deprecated since v15.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Font Awesome icons as React components",
   "main": "lib/index.js",
   "dependencies": {
-    "font-awesome": "^4.3.0"
+    "font-awesome": "^4.3.0",
+    "prop-types": "^15.5.6"
   },
   "peerDependencies": {
     "react": ">= 0.13.0 <16.0.0"

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -2,7 +2,8 @@
  * @copyright 2015, Andrey Popp <8mayday@gmail.com>
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class Icon extends React.Component {
 

--- a/src/IconStack.js
+++ b/src/IconStack.js
@@ -2,7 +2,8 @@
  * @copyright 2015, Andrey Popp <8mayday@gmail.com>
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class IconStack extends React.Component {
 


### PR DESCRIPTION
Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.