### PR TITLE
Don’t import PropTypes directly from react package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "file-loader": "^0.8.4",
     "mocha": "^2.3.2",
     "power-assert": "^1.0.0",
+    "prop-types": "^15.5.8",
     "react": "^15.0.0",
     "react-dom": "^15.0.1",
     "style-loader": "^0.12.0",

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -2,7 +2,8 @@
  * @copyright 2015, Andrey Popp <8mayday@gmail.com>
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class Icon extends React.Component {
 

--- a/src/IconStack.js
+++ b/src/IconStack.js
@@ -2,7 +2,8 @@
  * @copyright 2015, Andrey Popp <8mayday@gmail.com>
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class IconStack extends React.Component {
 


### PR DESCRIPTION
React.PropTypes is deprecated as of React v15.5
https://facebook.github.io/react/warnings/dont-call-proptypes.html